### PR TITLE
Fix missing report generator import

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,12 @@ except ImportError:
 # Import report generation module
 try:
     # CORRECTED: Import the EnhancedSPTReportGenerator class from the correct file
-    from enhanced_report_generator import EnhancedSPTReportGenerator
+    # Import both the report generator class and the helper function that
+    # displays the Streamlit interface.
+    from enhanced_report_generator import (
+        EnhancedSPTReportGenerator,
+        show_enhanced_report_generator,
+    )
     REPORT_GENERATOR_AVAILABLE = True
 except ImportError:
     REPORT_GENERATOR_AVAILABLE = False


### PR DESCRIPTION
## Summary
- ensure `app.py` imports `show_enhanced_report_generator` in addition to the report generator class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6859f07fa28083208f7825d040b0d608