### PR TITLE
Implement missing load methods

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -117,6 +117,21 @@ class StateManager:
         if value <= 0:
             raise ValueError("Pixel size must be positive")
         st.session_state.pixel_size = value
+
+    def load_tracks(self, df: pd.DataFrame, source: str = None):
+        """Load track data and reset related state."""
+        self.set_tracks(df, filename=source)
+        st.session_state.track_statistics = None
+        st.session_state.analysis_results = {}
+
+    def load_image_data(self, image_data: Any, metadata: Optional[Dict[str, Any]] = None):
+        """Load image data with optional metadata."""
+        self.set_image_data(image_data)
+        if metadata is not None:
+            if 'image_metadata' not in st.session_state:
+                st.session_state.image_metadata = {}
+            if isinstance(metadata, dict):
+                st.session_state.image_metadata.update(metadata)
     
 
     


### PR DESCRIPTION
## Summary
- fix AttributeError by implementing `load_tracks` and `load_image_data`
- reset statistics and store metadata when loading new data

## Testing
- `pytest -q` *(fails: test_batch_processing_imports, test_project_manager_batch_methods, test_enhanced_report_generator, test_imports, test_utils_functions, test_enhanced_error_handling, test_pdf_export, test_project_creation_and_batch_processing, test_segmentation_imports)*

------
https://chatgpt.com/codex/tasks/task_e_6859f51c62248320b526feda61452bdb