### PR TITLE
Integrate diffusion simulator with MD analysis

### DIFF
--- a/test_md_diffusion_integration.py
+++ b/test_md_diffusion_integration.py
@@ -1,0 +1,11 @@
+import numpy as np
+from md_integration import MDSimulation
+
+
+def test_md_run_local_diffusion():
+    sim = MDSimulation()
+    diameters = [5, 10]
+    results = sim.run_local_diffusion(diameters, mobility=0.5, num_steps=50)
+    assert not results.empty
+    assert set(results['particle_diameter']) == set(diameters)
+    print("✓ MDSimulation local diffusion works")


### PR DESCRIPTION
## Summary
- import `DiffusionSimulator` in `md_integration`
- add `_load_binary_trajectory_file` alias for binary trajectory parsing
- implement `run_local_diffusion` method in `MDSimulation`
- add tests for the new integration

## Testing
- `pytest -q test_md_diffusion_integration.py`
- `pytest -q` *(fails: Expected None, but test returned ...)*

------
https://chatgpt.com/codex/tasks/task_e_6859f957a19883209020c44787f4cb4d